### PR TITLE
set pfw's commentstring

### DIFF
--- a/ftdetect/pfw.vim
+++ b/ftdetect/pfw.vim
@@ -2,4 +2,4 @@
 au BufRead,BufNewFile *.{pfw}   set filetype=pfw"
 
 " Disable expandtab since pfw tabs are part of language
-autocmd FileType pfw set noet sw=4 sts=4 ts=4 tabstop=4
+autocmd FileType pfw set noet sw=4 sts=4 ts=4 tabstop=4 commentstring=#%s


### PR DESCRIPTION
The EDD syntax for comments is similar to python: lines starting with a # are comments
